### PR TITLE
add second param to template handler

### DIFF
--- a/lib/caracal/rails/template_handler.rb
+++ b/lib/caracal/rails/template_handler.rb
@@ -2,7 +2,7 @@ module Caracal
   module Rails
     class TemplateHandler
       
-      def self.call(template)
+      def self.call(template, source = nil)
         "Tilt.new('#{ template.identifier }').render(self)"
       end
       


### PR DESCRIPTION
Addresses https://github.com/urvin-compliance/caracal-rails/issues/8

```
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Caracal::Rails::TemplateHandler.call(template)
To:
  >> Caracal::Rails::TemplateHandler.call(template, source)
```